### PR TITLE
chore: update copyright year to 2021

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -27,7 +27,7 @@ Please see our [support](SUPPORT.md) documentation for further instructions.
 ## Copyright and License
 
 ```
-Copyright (c) 2020 Target Brands, Inc.
+Copyright (c) 2021 Target Brands, Inc.
 ```
 
 [![license](https://img.shields.io/crates/l/gl.svg)](LICENSE)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2020 Target Brands, Inc.
+   Copyright (c) 2021 Target Brands, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+# Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/apply.go
+++ b/cmd/vela-terraform/apply.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/apply_test.go
+++ b/cmd/vela-terraform/apply_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/command.go
+++ b/cmd/vela-terraform/command.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/command_test.go
+++ b/cmd/vela-terraform/command_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/config.go
+++ b/cmd/vela-terraform/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/config_test.go
+++ b/cmd/vela-terraform/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/destroy.go
+++ b/cmd/vela-terraform/destroy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/destroy_test.go
+++ b/cmd/vela-terraform/destroy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/fmt.go
+++ b/cmd/vela-terraform/fmt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/fmt_test.go
+++ b/cmd/vela-terraform/fmt_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/init.go
+++ b/cmd/vela-terraform/init.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/init_test.go
+++ b/cmd/vela-terraform/init_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/main.go
+++ b/cmd/vela-terraform/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
@@ -26,7 +26,7 @@ func main() {
 	app.Name = "vela-terraform"
 	app.HelpName = "vela-terraform"
 	app.Usage = "Vela Terraform plugin for running Terraform"
-	app.Copyright = "Copyright (c) 2020 Target Brands, Inc. All rights reserved."
+	app.Copyright = "Copyright (c) 2021 Target Brands, Inc. All rights reserved."
 	app.Authors = []*cli.Author{
 		{
 			Name:  "Vela Admins",

--- a/cmd/vela-terraform/plan.go
+++ b/cmd/vela-terraform/plan.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/plan_test.go
+++ b/cmd/vela-terraform/plan_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/plugin.go
+++ b/cmd/vela-terraform/plugin.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/plugin_test.go
+++ b/cmd/vela-terraform/plugin_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/terraform.go
+++ b/cmd/vela-terraform/terraform.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/terraform_test.go
+++ b/cmd/vela-terraform/terraform_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/validate.go
+++ b/cmd/vela-terraform/validate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/cmd/vela-terraform/validate_test.go
+++ b/cmd/vela-terraform/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 


### PR DESCRIPTION
This is a general housekeeping task.

I used VS code's search and replace:

* Search: `Copyright (c) 2020`
* Replace: `Copyright (c) 2021`

At the top of every file, the new copyright statement now looks like:

```
// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
```