### PR TITLE
deps: update terraform to 0.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # set a global Docker argument for the default CLI version
 #
 # https://github.com/moby/moby/issues/37345
-ARG TERRAFORM_VERSION=0.12.26
+ARG TERRAFORM_VERSION=0.14.5
 
 ################################################################################
 ##     docker build --no-cache --target binary -t vela-terraform:binary .     ##


### PR DESCRIPTION
Should be noted that upgrading from 0.12 to 0.14 is not support for existing Terraform states, you instead need to go 0.12 > 0.13 > 0.14. Couple of thoughts on scenarios to account for this:

- Option 1: Users will need to specify the `version` parameter with 0.13 before utilizing this version
- Option 2: We cut two releases of the plugin (0.13 & 0.14) 

docs: https://www.terraform.io/upgrade-guides/0-13.html