### PR TITLE
fix(vars): utilize multiple flags and remove quotes

### DIFF
--- a/cmd/vela-terraform/apply.go
+++ b/cmd/vela-terraform/apply.go
@@ -127,7 +127,7 @@ func (a *Apply) Command(dir string) *exec.Cmd {
 		for _, v := range a.Vars {
 			vars += fmt.Sprintf("-var=%s ", v)
 		}
-		// add flag for Vars from provided validate command
+		// add flag for Vars from provided apply command
 		flags = append(flags, strings.TrimSuffix(vars, " "))
 	}
 

--- a/cmd/vela-terraform/apply.go
+++ b/cmd/vela-terraform/apply.go
@@ -125,10 +125,10 @@ func (a *Apply) Command(dir string) *exec.Cmd {
 	if len(a.Vars) > 0 {
 		var vars string
 		for _, v := range a.Vars {
-			vars += fmt.Sprintf(" %s", v)
+			vars += fmt.Sprintf("-var=%s ", v)
 		}
-		// add flag for Vars from provided apply command
-		flags = append(flags, fmt.Sprintf("-var=\"%s\"", strings.TrimPrefix(vars, " ")))
+		// add flag for Vars from provided validate command
+		flags = append(flags, strings.TrimSuffix(vars, " "))
 	}
 
 	// check if VarFiles is provided

--- a/cmd/vela-terraform/apply_test.go
+++ b/cmd/vela-terraform/apply_test.go
@@ -45,7 +45,7 @@ func TestTerraform_Apply_Command(t *testing.T) {
 		fmt.Sprintf("-state=%s", a.State),
 		fmt.Sprintf("-state-out=%s", a.StateOut),
 		fmt.Sprintf("-target=%s", a.Target),
-		fmt.Sprintf("-var=\"%s %s\"", a.Vars[0], a.Vars[1]),
+		fmt.Sprintf("-var=%s -var=%s", a.Vars[0], a.Vars[1]),
 		fmt.Sprintf("-var-file=%s -var-file=%s", a.VarFiles[0], a.VarFiles[1]),
 		a.Directory,
 	)

--- a/cmd/vela-terraform/destroy.go
+++ b/cmd/vela-terraform/destroy.go
@@ -119,7 +119,7 @@ func (a *Destroy) Command(dir string) *exec.Cmd {
 		for _, v := range a.Vars {
 			vars += fmt.Sprintf("-var=%s ", v)
 		}
-		// add flag for Vars from provided validate command
+		// add flag for Vars from provided destroy command
 		flags = append(flags, strings.TrimSuffix(vars, " "))
 	}
 

--- a/cmd/vela-terraform/destroy.go
+++ b/cmd/vela-terraform/destroy.go
@@ -117,10 +117,10 @@ func (a *Destroy) Command(dir string) *exec.Cmd {
 	if len(a.Vars) > 0 {
 		var vars string
 		for _, v := range a.Vars {
-			vars += fmt.Sprintf(" %s", v)
+			vars += fmt.Sprintf("-var=%s ", v)
 		}
-		// add flag for Vars from provided destroy command
-		flags = append(flags, fmt.Sprintf("-var=\"%s\"", strings.TrimPrefix(vars, " ")))
+		// add flag for Vars from provided validate command
+		flags = append(flags, strings.TrimSuffix(vars, " "))
 	}
 
 	// check if VarFiles is provided

--- a/cmd/vela-terraform/destroy_test.go
+++ b/cmd/vela-terraform/destroy_test.go
@@ -43,7 +43,7 @@ func TestTerraform_Destroy_Command(t *testing.T) {
 		fmt.Sprintf("-state=%s", d.State),
 		fmt.Sprintf("-state-out=%s", d.StateOut),
 		fmt.Sprintf("-target=%s", d.Target),
-		fmt.Sprintf("-var=\"%s %s\"", d.Vars[0], d.Vars[1]),
+		fmt.Sprintf("-var=%s -var=%s", d.Vars[0], d.Vars[1]),
 		fmt.Sprintf("-var-file=%s -var-file=%s", d.VarFiles[0], d.VarFiles[1]),
 		d.Directory,
 	)

--- a/cmd/vela-terraform/plan.go
+++ b/cmd/vela-terraform/plan.go
@@ -133,11 +133,10 @@ func (p *Plan) Command(dir string) *exec.Cmd {
 	if len(p.Vars) > 0 {
 		var vars string
 		for _, v := range p.Vars {
-			vars += fmt.Sprintf(" %s", v)
+			vars += fmt.Sprintf("-var=%s ", v)
 		}
-
-		// add flag for Vars from provided plan command
-		flags = append(flags, fmt.Sprintf("-var=\"%s\"", strings.TrimPrefix(vars, " ")))
+		// add flag for Vars from provided validate command
+		flags = append(flags, strings.TrimSuffix(vars, " "))
 	}
 
 	// check if VarFiles is provided

--- a/cmd/vela-terraform/plan.go
+++ b/cmd/vela-terraform/plan.go
@@ -135,7 +135,7 @@ func (p *Plan) Command(dir string) *exec.Cmd {
 		for _, v := range p.Vars {
 			vars += fmt.Sprintf("-var=%s ", v)
 		}
-		// add flag for Vars from provided validate command
+		// add flag for Vars from provided plan command
 		flags = append(flags, strings.TrimSuffix(vars, " "))
 	}
 

--- a/cmd/vela-terraform/plan_test.go
+++ b/cmd/vela-terraform/plan_test.go
@@ -47,7 +47,7 @@ func TestTerraform_Plan_Command(t *testing.T) {
 		"-refresh=true",
 		fmt.Sprintf("-state=%s", p.State),
 		fmt.Sprintf("-target=%s", p.Target),
-		fmt.Sprintf("-var=\"%s %s\"", p.Vars[0], p.Vars[1]),
+		fmt.Sprintf("-var=%s -var=%s", p.Vars[0], p.Vars[1]),
 		fmt.Sprintf("-var-file=%s -var-file=%s", p.VarFiles[0], p.VarFiles[1]),
 		p.Directory,
 	)

--- a/cmd/vela-terraform/validate.go
+++ b/cmd/vela-terraform/validate.go
@@ -52,10 +52,10 @@ func (v *Validation) Command(dir string) *exec.Cmd {
 	if len(v.Vars) > 0 {
 		var vars string
 		for _, v := range v.Vars {
-			vars += fmt.Sprintf(" %s", v)
+			vars += fmt.Sprintf("-var=%s ", v)
 		}
 		// add flag for Vars from provided validate command
-		flags = append(flags, fmt.Sprintf("-var=\"%s\"", strings.TrimPrefix(vars, " ")))
+		flags = append(flags, strings.TrimSuffix(vars, " "))
 	}
 
 	// check if VarFiles is provided

--- a/cmd/vela-terraform/validate_test.go
+++ b/cmd/vela-terraform/validate_test.go
@@ -26,7 +26,7 @@ func TestTerraform_Validation_Command(t *testing.T) {
 		validationAction,
 		fmt.Sprintf("-check-variables=%t", v.CheckVariables),
 		"-no-color",
-		fmt.Sprintf("-var=\"%s %s\"", v.Vars[0], v.Vars[1]),
+		fmt.Sprintf("-var=%s -var=%s", v.Vars[0], v.Vars[1]),
 		fmt.Sprintf("-var-file=%s -var-file=%s", v.VarFiles[0], v.VarFiles[1]),
 		v.Directory,
 	)


### PR DESCRIPTION
Fixed the following:

- Changed from syntax of `-var="var1=value1 var2=value"` to `-var=var1=value1 -var=var1=value2` since Terraform does not properly parse the original string
- Removed the quotes since they were causing Terraform to add them within the variable name