### PR TITLE
fix: respect directory when downloading modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,12 @@ ARG TERRAFORM_VERSION=0.14.5
 ##     docker build --no-cache --target binary -t vela-terraform:binary .     ##
 ################################################################################
 
-FROM alpine:latest as binary
+FROM alpine:3.12 as binary
+ADD http://browserconfig.target.com/tgt-certs/tgt-ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
 
 ARG TERRAFORM_VERSION
 
-RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -O terraform.zip && \
+RUN wget -q https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_linux_amd64.zip -O terraform.zip && \
   unzip terraform.zip -d /bin && \
   rm -f terraform.zip
 
@@ -23,7 +24,7 @@ RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraf
 ##     docker build --no-cache --target certs -t vela-terraform:certs .     ##
 ##############################################################################
 
-FROM alpine:latest as certs
+FROM alpine:3.12 as certs
 
 RUN apk add --update --no-cache ca-certificates
 
@@ -31,11 +32,11 @@ RUN apk add --update --no-cache ca-certificates
 ##     docker build --no-cache -t vela-terraform:local .     ##
 ###############################################################
 
-FROM alpine:3.13.0
+FROM alpine:3.12.0
 
 ARG TERRAFORM_VERSION
 
-ENV PLUGIN_TERRAFORM_VERSION=${TERRAFORM_VERSION}
+ENV PLUGIN_TERRAFORM_VERSION=0.14.5
 
 COPY --from=binary /bin/terraform /bin/terraform
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,11 @@ ARG TERRAFORM_VERSION=0.14.5
 ##     docker build --no-cache --target binary -t vela-terraform:binary .     ##
 ################################################################################
 
-FROM alpine:3.12 as binary
-ADD http://browserconfig.target.com/tgt-certs/tgt-ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+FROM alpine:latest as binary
 
 ARG TERRAFORM_VERSION
 
-RUN wget -q https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_linux_amd64.zip -O terraform.zip && \
+RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -O terraform.zip && \
   unzip terraform.zip -d /bin && \
   rm -f terraform.zip
 
@@ -24,7 +23,7 @@ RUN wget -q https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_lin
 ##     docker build --no-cache --target certs -t vela-terraform:certs .     ##
 ##############################################################################
 
-FROM alpine:3.12 as certs
+FROM alpine:latest as certs
 
 RUN apk add --update --no-cache ca-certificates
 
@@ -32,11 +31,11 @@ RUN apk add --update --no-cache ca-certificates
 ##     docker build --no-cache -t vela-terraform:local .     ##
 ###############################################################
 
-FROM alpine:3.12.0
+FROM alpine:3.13.0
 
 ARG TERRAFORM_VERSION
 
-ENV PLUGIN_TERRAFORM_VERSION=0.14.5
+ENV PLUGIN_TERRAFORM_VERSION=${TERRAFORM_VERSION}
 
 COPY --from=binary /bin/terraform /bin/terraform
 

--- a/cmd/vela-terraform/command.go
+++ b/cmd/vela-terraform/command.go
@@ -31,10 +31,24 @@ func execCmd(e *exec.Cmd) error {
 
 // getCmd is a helper function to retrieve
 // the terraform modules required for the files.
-func getCmd() *exec.Cmd {
-	return exec.Command(
-		"terraform",
+func getCmd(dir string) *exec.Cmd {
+
+	// name of cmd
+	name := "terraform"
+
+	// default arg
+	args := []string{
 		"get",
+	}
+
+	// set working directory if provided
+	if len(dir) > 0 {
+		args = append(args, fmt.Sprintf("-chdir=%s", dir))
+	}
+
+	return exec.Command(
+		name,
+		args...,
 	)
 }
 

--- a/cmd/vela-terraform/command.go
+++ b/cmd/vela-terraform/command.go
@@ -33,17 +33,15 @@ func execCmd(e *exec.Cmd) error {
 // the terraform modules required for the files.
 func getCmd(dir string) *exec.Cmd {
 
-	// name of cmd
+	// default cmd and arg
 	name := "terraform"
-
-	// default arg
 	args := []string{
 		"get",
 	}
 
 	// set working directory if provided
 	if len(dir) > 0 {
-		args = append(args, fmt.Sprintf("-chdir=%s", dir))
+		args = append(args, dir)
 	}
 
 	return exec.Command(

--- a/cmd/vela-terraform/command.go
+++ b/cmd/vela-terraform/command.go
@@ -32,7 +32,6 @@ func execCmd(e *exec.Cmd) error {
 // getCmd is a helper function to retrieve
 // the terraform modules required for the files.
 func getCmd(dir string) *exec.Cmd {
-
 	// default cmd and arg
 	name := "terraform"
 	args := []string{

--- a/cmd/vela-terraform/plugin.go
+++ b/cmd/vela-terraform/plugin.go
@@ -60,7 +60,7 @@ func (p *Plugin) Exec() error {
 	}
 
 	// retrieve terraform modules for actions
-	err = execCmd(getCmd())
+	err = execCmd(getCmd(p.Init.Directory))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes a bug where a custom `directory` is not respected during the interim `terraform get`