### PR TITLE
fix: configure TF_VAR env

### DIFF
--- a/cmd/vela-terraform/plugin.go
+++ b/cmd/vela-terraform/plugin.go
@@ -65,6 +65,12 @@ func (p *Plugin) Exec() error {
 		return err
 	}
 
+	// configure the terraform environment
+	err = env()
+	if err != nil {
+		return err
+	}
+
 	// execute action specific configuration
 	switch p.Config.Action {
 	case applyAction:

--- a/cmd/vela-terraform/terraform.go
+++ b/cmd/vela-terraform/terraform.go
@@ -6,6 +6,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"regexp"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -59,5 +61,32 @@ func install(customVer, defaultVer string) error {
 		return err
 	}
 
+	return nil
+}
+
+// sets up environment for terraform
+func env() error {
+	// regexp for TF_VAR_ terraform vars
+	tfVar := regexp.MustCompile(`^TF_VAR_.*$`)
+
+	// match terraform vars in environment
+	for _, e := range os.Environ() {
+		// split on value
+		pair := strings.SplitN(e, "=", 2)
+
+		// match on TF_VAR_*
+		if tfVar.MatchString(pair[0]) {
+			// pull out the name
+			name := strings.Split(pair[0], "TF_VAR_")
+
+			// lower case the terraform variable
+			//   to accomodate cicd injection capitalization
+			err := os.Setenv(fmt.Sprintf("TF_VAR_%s",
+				strings.ToLower(name[1])), pair[1])
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }

--- a/cmd/vela-terraform/terraform.go
+++ b/cmd/vela-terraform/terraform.go
@@ -80,7 +80,7 @@ func env() error {
 			name := strings.Split(pair[0], "TF_VAR_")
 
 			// lower case the terraform variable
-			//   to accomodate cicd injection capitalization
+			//   to accommodate cicd injection capitalization
 			err := os.Setenv(fmt.Sprintf("TF_VAR_%s",
 				strings.ToLower(name[1])), pair[1])
 			if err != nil {

--- a/cmd/vela-terraform/terraform_test.go
+++ b/cmd/vela-terraform/terraform_test.go
@@ -80,3 +80,11 @@ func TestTerraform_env(t *testing.T) {
 		t.Errorf("os.Getenv is %v, want %v", got, want)
 	}
 }
+
+func TestTerraform_env_err(t *testing.T) {
+	// run env
+	err := env()
+	if err != nil {
+		t.Errorf("env returned err: %v", err)
+	}
+}

--- a/cmd/vela-terraform/terraform_test.go
+++ b/cmd/vela-terraform/terraform_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -50,5 +51,32 @@ func TestTerraform_install_NotWritable(t *testing.T) {
 	err = install("0.11.0", "0.12.0")
 	if err == nil {
 		t.Errorf("install should have returned err")
+	}
+}
+
+func TestTerraform_env(t *testing.T) {
+	want := "abc123"
+	up := "TF_VAR_CHEF_PRIVATE_KEY"
+	low := "TF_VAR_chef_private_key"
+
+	// setup env
+	os.Setenv(up, want)
+
+	// check env
+	got := os.Getenv(low)
+	if got == want {
+		t.Errorf("os.Getenv should not be %v", got)
+	}
+
+	// run env
+	err := env()
+	if err != nil {
+		t.Errorf("env returned err: %v", err)
+	}
+
+	// check new env for same value
+	got = os.Getenv(low)
+	if got != want {
+		t.Errorf("os.Getenv is %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
Vela (and other cicd, drone etc) inject secrets as their capitalized key.

terraform requires environment variables be of the form `TF_VAR_lowercase_key` 
https://www.terraform.io/docs/cli/config/environment-variables.html#tf_var_name


this code accounts for that 