### PR TITLE
feat: enable setting --out in terraform plan

### DIFF
--- a/cmd/vela-terraform/main.go
+++ b/cmd/vela-terraform/main.go
@@ -373,6 +373,7 @@ func run(c *cli.Context) error {
 			Parallelism:      c.Int("parallelism"),
 			Refresh:          c.Bool("refresh"),
 			State:            c.String("state"),
+			Out:              c.String("state_out"),
 			Target:           c.String("target"),
 			Vars:             c.StringSlice("vars"),
 			VarFiles:         c.StringSlice("var_files"),


### PR DESCRIPTION
Fixes https://github.com/go-vela/community/issues/249

allows user to set the `--out` terraform cli flag via `state-out` var similar to plan and destroy.