### PR TITLE
fix: update default terraform version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # set a global Docker argument for the default CLI version
 #
 # https://github.com/moby/moby/issues/37345
-ARG TERRAFORM_VERSION=0.14.5
+ARG TERRAFORM_VERSION=0.15.1
 
 ################################################################################
 ##     docker build --no-cache --target binary -t vela-terraform:binary .     ##


### PR DESCRIPTION
Terraform recently ran into an issue where they had to update their public keys. Older versions without those new public keys have download issues when installing plugins during `terraform init`

Terraform GitHub issue on plugin download issues:
https://github.com/hashicorp/terraform/issues/28518