### PR TITLE
fix: wrap --backend-config values in single quotes

### DIFF
--- a/cmd/vela-terraform/init.go
+++ b/cmd/vela-terraform/init.go
@@ -83,7 +83,7 @@ func (i *Init) Command(dir string) *exec.Cmd {
 	if len(i.InitOptions.BackendConfigs) > 0 {
 		var configs string
 		for _, v := range i.InitOptions.BackendConfigs {
-			configs += fmt.Sprintf("-backend-config=%s ", v)
+			configs += fmt.Sprintf("-backend-config='%s' ", v)
 		}
 
 		// add flag for BackendConfigs from provided init command

--- a/cmd/vela-terraform/init_test.go
+++ b/cmd/vela-terraform/init_test.go
@@ -38,7 +38,7 @@ func TestTerraform_Init_Command(t *testing.T) {
 		_terraform,
 		initAction,
 		"-backend=true",
-		fmt.Sprintf("-backend-config=%s -backend-config=%s", i.InitOptions.BackendConfigs[0], i.InitOptions.BackendConfigs[1]),
+		fmt.Sprintf("-backend-config='%s' -backend-config='%s'", i.InitOptions.BackendConfigs[0], i.InitOptions.BackendConfigs[1]),
 		"-force-copy",
 		fmt.Sprintf("-from-module=%s", i.InitOptions.FromModule),
 		"-get=true",


### PR DESCRIPTION
from `terraform init --help`
```
  -backend-config=path This can be either a path to an HCL file with key/value
                       assignments (same format as terraform.tfvars) or a
                       'key=value' format. This is merged with what is in the
                       configuration file. This can be specified multiple
                       times. The backend type must be in the configuration
                       itself.
```

A user ran into an instance with multiple backend-configs where they were being concatenated. this should help avoid that.