### PR TITLE
deps: bump terraform to 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # set a global Docker argument for the default CLI version
 #
 # https://github.com/moby/moby/issues/37345
-ARG TERRAFORM_VERSION=0.15.1
+ARG TERRAFORM_VERSION=1.0.0
 
 ################################################################################
 ##     docker build --no-cache --target binary -t vela-terraform:binary .     ##


### PR DESCRIPTION
Bumping the bundled version of Terraform from 0.15.1 to 1.0.0. The release notes from Terraform specifically call this change out as non breaking even though it bumps the major release:

> Terraform v1.0.0 intentionally has no significant changes compared to Terraform v0.15.5. You can consider the v1.0 series as a direct continuation of the v0.15 series; we do not intend to issue any further releases in the v0.15 series, because all of the v1.0 releases will be only minor updates to address bugs.

Source: https://github.com/hashicorp/terraform/releases/tag/v1.0.0