### PR TITLE
chore: upgrade Terraform to 1.1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # set a global Docker argument for the default CLI version
 #
 # https://github.com/moby/moby/issues/37345
-ARG TERRAFORM_VERSION=1.0.0
+ARG TERRAFORM_VERSION=1.1.6
 
 ################################################################################
 ##     docker build --no-cache --target binary -t vela-terraform:binary .     ##


### PR DESCRIPTION
This upgrades the version of Terraform from `1.0.0` to `1.1.6`:

https://www.terraform.io/downloads

https://github.com/hashicorp/terraform/releases/tag/v1.1.6