### PR TITLE
chore: update Terraform version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # set a global Docker argument for the default CLI version
 #
 # https://github.com/moby/moby/issues/37345
-ARG TERRAFORM_VERSION=1.6.1
+ARG TERRAFORM_VERSION=1.7.4
 
 ################################################################################
 ##     docker build --no-cache --target binary -t vela-terraform:binary .     ##


### PR DESCRIPTION
Upgrade to the latest stable release of Terraform to include the fix from https://github.com/hashicorp/terraform/issues/34108 that was released in Terraform 1.6.2.