### PR TITLE
fix: copy curl from image layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ ENV PLUGIN_TERRAFORM_VERSION=${TERRAFORM_VERSION}
 
 COPY --from=binary /bin/terraform /bin/terraform
 
+COPY --from=certs /usr/bin/curl /bin/curl
+
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 COPY release/vela-terraform /bin/terraform-plugin

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN wget -q "${TERRAFORM_RELEASE_URL}/${TERRAFORM_ZIP_FILENAME}" -O "${TERRAFORM
 
 FROM alpine:latest@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5 as certs
 
-RUN apk add --update --no-cache ca-certificates curl
+RUN apk add --update --no-cache ca-certificates
 
 ###############################################################
 ##     docker build --no-cache -t vela-terraform:local .     ##
@@ -38,13 +38,13 @@ RUN apk add --update --no-cache ca-certificates curl
 
 FROM alpine:3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
 
+RUN apk add --update --no-cache curl
+
 ARG TERRAFORM_VERSION
 
 ENV PLUGIN_TERRAFORM_VERSION=${TERRAFORM_VERSION}
 
 COPY --from=binary /bin/terraform /bin/terraform
-
-COPY --from=certs /usr/bin/curl /bin/curl
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
moving `apk add curl` to the final image layer.

to install curl then COPY it, you would need to also COPY the following shared libraries to make it actually work
```
# ldd /usr/bin/curl
	/lib/ld-musl-aarch64.so.1 (0xffff84954000)
	libcurl.so.4 => /usr/lib/libcurl.so.4 (0xffff84850000)
	libz.so.1 => /lib/libz.so.1 (0xffff8481f000)
	libc.musl-aarch64.so.1 => /lib/ld-musl-aarch64.so.1 (0xffff84954000)
	libcares.so.2 => /usr/lib/libcares.so.2 (0xffff847de000)
	libnghttp2.so.14 => /usr/lib/libnghttp2.so.14 (0xffff8479d000)
	libidn2.so.0 => /usr/lib/libidn2.so.0 (0xffff8475c000)
	libpsl.so.5 => /usr/lib/libpsl.so.5 (0xffff8473b000)
	libssl.so.3 => /lib/libssl.so.3 (0xffff84657000)
	libcrypto.so.3 => /lib/libcrypto.so.3 (0xffff841f1000)
	libzstd.so.1 => /usr/lib/libzstd.so.1 (0xffff84140000)
	libbrotlidec.so.1 => /usr/lib/libbrotlidec.so.1 (0xffff8411f000)
	libunistring.so.5 => /usr/lib/libunistring.so.5 (0xffff83f5d000)
	libbrotlicommon.so.1 => /usr/lib/libbrotlicommon.so.1 (0xffff83f2c000)
```

to me, just doing an `apk add curl` in the final image is more sustainable, considering its not even a scratch image, its alpine.

any thoughts? 