### PR TITLE
chore: consistent golangci lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,10 @@
 # outputs it results from the linters it executes.
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
+  formats:
+    - format: json
+      path: stderr
+    - format: colored-line-number
 
   # print lines of code with issue, default is true
   print-issued-lines: true
@@ -32,6 +35,18 @@ linters-settings:
     lines: 160
     statements: 70
 
+  # https://github.com/daixiang0/gci
+  # ensure import order is consistent
+  # gci write --custom-order -s standard -s default -s blank -s dot -s "prefix(github.com/go-vela)" .
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - blank
+      - dot
+      - prefix(github.com/go-vela)
+
   # https://github.com/denis-tingaikin/go-header
   goheader:
     template: |-
@@ -43,9 +58,9 @@ linters-settings:
 
   # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
   nolintlint:
-    allow-unused: false           # allow nolint directives that don't address a linting issue
-    require-explanation: true     # require an explanation for nolint directives
-    require-specific: true        # require nolint directives to be specific about which linter is being skipped
+    allow-unused: false # allow nolint directives that don't address a linting issue
+    require-explanation: true # require an explanation for nolint directives
+    require-specific: true # require nolint directives to be specific about which linter is being skipped
 
 # This section provides the configuration for which linters
 # golangci will execute. Several of them were disabled by
@@ -56,46 +71,43 @@ linters:
 
   # enable a specific set of linters to run
   enable:
-    - bidichk             # checks for dangerous unicode character sequences
-    - bodyclose           # checks whether HTTP response body is closed successfully
-    - contextcheck        # check the function whether use a non-inherited context
-    - deadcode            # finds unused code
-    - dupl                # code clone detection
-    - errcheck            # checks for unchecked errors
-    - errorlint           # find misuses of errors
-    - exportloopref       # check for exported loop vars
-    - funlen              # detects long functions
-    - goconst             # finds repeated strings that could be replaced by a constant
-    - gocyclo             # computes and checks the cyclomatic complexity of functions
-    - godot               # checks if comments end in a period
-    - gofmt               # checks whether code was gofmt-ed
-    - goheader            # checks is file header matches to pattern
-    - goimports           # fixes imports and formats code in same style as gofmt
-    - gomoddirectives     # manage the use of 'replace', 'retract', and 'excludes' directives in go.mod
-    - goprintffuncname    # checks that printf-like functions are named with f at the end
-    - gosec               # inspects code for security problems
-    - gosimple            # linter that specializes in simplifying a code
-    - govet               # reports suspicious constructs, ex. Printf calls whose arguments don't align with the format string
-    - ineffassign         # detects when assignments to existing variables aren't used
-    - makezero            # finds slice declarations with non-zero initial length
-    - misspell            # finds commonly misspelled English words in comments
-    - nakedret            # finds naked returns in functions greater than a specified function length
-    - nilerr              # finds the code that returns nil even if it checks that the error is not nil
-    - noctx               # noctx finds sending http request without context.Context
-    - nolintlint          # reports ill-formed or insufficient nolint directives
-    - revive              # linter for go
-    - staticcheck         # applies static analysis checks, go vet on steroids
-    - structcheck         # finds unused struct fields
-    - stylecheck          # replacement for golint
-    - tenv                # analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
-    - typecheck           # parses and type-checks go code, like the front-end of a go compiler
-    - unconvert           # remove unnecessary type conversions
-    - unparam             # reports unused function parameters
-    - unused              # checks for unused constants, variables, functions and types
-    - varcheck            # finds unused global variables and constants
-    - whitespace          # detects leading and trailing whitespace
-    - wsl                 # forces code to use empty lines
-    
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - contextcheck # check the function whether use a non-inherited context
+    - dupl # code clone detection
+    - errcheck # checks for unchecked errors
+    - errorlint # find misuses of errors
+    - exportloopref # check for exported loop vars
+    - funlen # detects long functions
+    - gci # consistent import ordering
+    - goconst # finds repeated strings that could be replaced by a constant
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    - godot # checks if comments end in a period
+    - gofmt # checks whether code was gofmt-ed
+    - goheader # checks is file header matches to pattern
+    - gomoddirectives # manage the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - gosec # inspects code for security problems
+    - gosimple # linter that specializes in simplifying a code
+    - govet # reports suspicious constructs, ex. Printf calls whose arguments don't align with the format string
+    - ineffassign # detects when assignments to existing variables aren't used
+    - makezero # finds slice declarations with non-zero initial length
+    - misspell # finds commonly misspelled English words in comments
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - noctx # noctx finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - revive # linter for go
+    - staticcheck # applies static analysis checks, go vet on steroids
+    - stylecheck # replacement for golint
+    - tenv # analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
+    - typecheck # parses and type-checks go code, like the front-end of a go compiler
+    - unconvert # remove unnecessary type conversions
+    - unparam # reports unused function parameters
+    - unused # checks for unused constants, variables, functions and types
+    - whitespace # detects leading and trailing whitespace
+    - wsl # forces code to use empty lines
+
   # static list of linters we know golangci can run but we've
   # chosen to leave disabled for now
   # - asciicheck          - non-critical
@@ -108,13 +120,13 @@ linters:
   # - exhaustivestruct    - style preference
   # - forbidigo           - unused
   # - forcetypeassert     - unused
-  # - gci                 - use goimports
   # - gochecknoinits      - unused
   # - gochecknoglobals    - global variables allowed
-  # - gocognit            - unused complexity metric 
+  # - gocognit            - unused complexity metric
   # - gocritic            - style preference
   # - godox               - to be used in the future
   # - goerr113            - to be used in the future
+  # - goimports           - use gci
   # - golint              - archived, replaced with revive
   # - gofumpt             - use gofmt
   # - gomnd               - get too many false-positives
@@ -122,7 +134,7 @@ linters:
   # - ifshort             - use both styles
   # - ireturn             - allow interfaces to be returned
   # - importas            - want flexibility with naming
-  # - lll                 - not too concerned about line length 
+  # - lll                 - not too concerned about line length
   # - interfacer          - archived
   # - nestif              - non-critical
   # - nilnil              - style preference
@@ -131,7 +143,7 @@ linters:
   # - paralleltest        - false-positives
   # - prealloc            - don't use
   # - predeclared         - unused
-  # - promlinter          - style preference 
+  # - promlinter          - style preference
   # - rowserrcheck        - unused
   # - scopelint           - deprecated - replaced with exportloopref
   # - sqlclosecheck       - unused
@@ -154,3 +166,4 @@ issues:
         - funlen
         - goconst
         - gocyclo
+        - wsl

--- a/cmd/vela-terraform/apply.go
+++ b/cmd/vela-terraform/apply.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/cmd/vela-terraform/destroy.go
+++ b/cmd/vela-terraform/destroy.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/cmd/vela-terraform/fmt.go
+++ b/cmd/vela-terraform/fmt.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/cmd/vela-terraform/main.go
+++ b/cmd/vela-terraform/main.go
@@ -9,13 +9,12 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-
-	"github.com/go-vela/vela-terraform/version"
-
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
 	_ "github.com/joho/godotenv/autoload"
+
+	"github.com/go-vela/vela-terraform/version"
 )
 
 //nolint:funlen // ignore function length due to comments and flags

--- a/cmd/vela-terraform/plan.go
+++ b/cmd/vela-terraform/plan.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/cmd/vela-terraform/terraform.go
+++ b/cmd/vela-terraform/terraform.go
@@ -9,14 +9,13 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
-
 	"github.com/hashicorp/go-version"
 	install "github.com/hashicorp/hc-install"
 	"github.com/hashicorp/hc-install/product"
 	"github.com/hashicorp/hc-install/releases"
 	"github.com/hashicorp/hc-install/src"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 )
 
 const (

--- a/cmd/vela-terraform/validate.go
+++ b/cmd/vela-terraform/validate.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-
 	"github.com/sirupsen/logrus"
 )
 

--- a/version/version.go
+++ b/version/version.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/go-vela/types/version"
+	"github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 
-	"github.com/Masterminds/semver/v3"
+	"github.com/go-vela/types/version"
 )
 
 var (


### PR DESCRIPTION
applying consistent linting across repos, see https://github.com/go-vela/server/blob/main/.golangci.yml